### PR TITLE
Remove sub-second details from feedback window

### DIFF
--- a/MainForm.cs
+++ b/MainForm.cs
@@ -228,8 +228,10 @@ namespace VideoMotionDetect
 					Properties.Resources.BackgroundWorkerError, e.Error.ToString()),
 					this.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
 
+            TimeSpan duration = DateTime.Now.Subtract((DateTime)e.Result);
+			
 			MessageBox.Show(this, string.Format(CultureInfo.CurrentCulture,
-				Properties.Resources.Finished, DateTime.Now.Subtract((DateTime)e.Result)),
+				Properties.Resources.Finished, duration.ToString("hh\\:mm\\:ss")),
 				Properties.Resources.FinishedTitle, MessageBoxButtons.OK, MessageBoxIcon.None);
 		}
 	}


### PR DESCRIPTION
The feedback window shown at end include sub-second accuracy, wheras jobs run for minutes or longer. High accuracy provides little to no value to user.